### PR TITLE
clear() to allow pattern re-scanning

### DIFF
--- a/Hooking.Patterns.h
+++ b/Hooking.Patterns.h
@@ -135,6 +135,13 @@ namespace hook
 			return *this;
 		}
 
+		inline pattern& clear()
+		{
+			m_matches.clear();
+			m_matched = false;
+			return *this;
+		}
+
 		inline size_t size()
 		{
 			EnsureMatches(UINT32_MAX);


### PR DESCRIPTION
No need to instance a new pattern object in order to re-scan a pattern now.